### PR TITLE
feat: add support for Bluesky

### DIFF
--- a/_data/data.yml
+++ b/_data/data.yml
@@ -24,7 +24,7 @@ sidebar:
     telegram: plinkr # add your nickname without '@' sign
     gitlab: plinkr
     bitbucket:
-    twitter: '@plinker'
+    bluesky: '@plinkr.bsky.social'
     stack-overflow: # Number/Username, e.g. 123456/alandoe
     codewars:
     goodreads: # Number-Username, e.g. 123456-alandoe

--- a/_includes/contact.html
+++ b/_includes/contact.html
@@ -79,7 +79,14 @@
       <a href="{{ sidebar.mastodon }}" target="_blank">{{ mastodon_handle[3] }}@{{ mastodon_handle[2] }}</a>
     </li>
     {% endif %}
-
+    
+	{% if sidebar.bluesky %}
+	{% assign bluesky_handle = sidebar.bluesky | remove: '@' %}
+	<li class="bluesky"><i class="fab fa-bluesky"></i>
+	  <a href="https://bsky.app/profile/{{ bluesky_handle }}" target="_blank">{{ sidebar.bluesky }}</a>
+	</li>
+	{% endif %}
+    
     {% if sidebar.stack-overflow %}
     <li class="stack-overflow"><i class="fab fa-stack-overflow"></i>
       <a href="https://stackoverflow.com/users/{{ sidebar.stack-overflow }}" target="_blank">{{ sidebar.stack-overflow }}</a>


### PR DESCRIPTION
Introduces support for Bluesky.

The following changes were made to enable Bluesky integration:

- Added a new `bluesky` field to the `_data/data.yml` file to store the user's Bluesky handle.
- Updated the `_includes/contact.html` file to display the Bluesky icon and link to the user's profile if the `bluesky` field is set.